### PR TITLE
Remove cargo clean from run and update README with volume mounting ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you successfully pulled the `Docker image` containing the cross compiler, you
 $ docker run \
     --volume <path to your rust project directory>:/home/cross/project \
     --volume <path to directory containing the platform dependencies>:/home/cross/deb-deps \ # optional, see section "Platform dependencies"
+    --volume <path to local cargo registry, e.g. ~/.cargo/registry>:/home/cross/.cargo/registry \ # optional, using cached registry avoids updating on every build
     ragnaroek/rust-raspberry:<version>
     <cargo command> # e.g. "build --release"
 ```

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -28,5 +28,4 @@ export CC="$TOOLCHAIN/gcc-sysroot";
 export AR="$TOOLCHAIN/arm-linux-gnueabihf-ar";
 
 flags="--target=arm-unknown-linux-gnueabihf";
-$HOME/.cargo/bin/cargo clean;
 $HOME/.cargo/bin/cargo $@ $flags;


### PR DESCRIPTION
…rgo registry.

If you want to clean, you can always explicitly run the clean command, but I don't think there's any reason to clean on every build.