### PR TITLE
Extract scripts from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,36 +4,25 @@ ARG PI_TOOLS_GIT_REF=master
 ARG RUST_VERSION=stable
 
 # update system
-RUN apt-get update
-RUN apt-get install -y curl git gcc xz-utils sudo pkg-config unzip
+RUN apt-get update && \
+  apt-get install -y curl git gcc xz-utils sudo pkg-config unzip
+
 
 # config and set variables
 #
-# On OS X, the user needs to have uid set to 1000
-# in order to access files from the shared volumes.
-# https://medium.com/@brentkearney/docker-on-mac-os-x-9793ac024e94
-RUN groupadd --system cross && useradd --create-home --system --gid cross --uid 1000 cross;
-RUN adduser cross sudo
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+COPY build /tmp/build
+RUN sh /tmp/build/user-setup.sh
+
 USER cross
+
 ENV HOME=/home/cross
 ENV URL_GIT_PI_TOOLS=https://github.com/raspberrypi/tools.git \
     TOOLCHAIN_64=$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin \
     TOOLCHAIN_32=$HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin
 
 # install rustup with raspberry target
-RUN curl https://sh.rustup.rs -sSf > $HOME/install_rustup.sh
-RUN sh $HOME/install_rustup.sh -y --default-toolchain $RUST_VERSION
-RUN $HOME/.cargo/bin/rustup target add arm-unknown-linux-gnueabihf
+RUN sh /tmp/build/download-rust.sh
 
-# install pi tools
-RUN if [ $PI_TOOLS_GIT_REF = master ]; \
-    then git clone --depth 1 $URL_GIT_PI_TOOLS $HOME/pi-tools; \
-    else \
-      git clone $URL_GIT_PI_TOOLS $HOME/pi-tools \
-      && cd $HOME/pi-tools \
-      && git reset --hard $PI_TOOLS_GIT_REF; \
-    fi
 COPY bin/gcc-sysroot $HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/gcc-sysroot
 COPY bin/gcc-sysroot $HOME/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian/bin/gcc-sysroot
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,2 @@
+These are scripts used to build the docker image. They are referenced from Dockerfile and minimize
+the number of RUN statements and implicitly the number of layers.

--- a/build/download-rust.sh
+++ b/build/download-rust.sh
@@ -1,0 +1,18 @@
+
+# Exit if environment variables are not set
+set -u
+
+# Install rust through rustup
+curl https://sh.rustup.rs -sSf > $HOME/install_rustup.sh
+sh $HOME/install_rustup.sh -y --default-toolchain $RUST_VERSION
+$HOME/.cargo/bin/rustup target add arm-unknown-linux-gnueabihf
+
+# install pi tools
+if [ $PI_TOOLS_GIT_REF = master ]; \
+then git clone --depth 1 $URL_GIT_PI_TOOLS $HOME/pi-tools; \
+else \
+  git clone $URL_GIT_PI_TOOLS $HOME/pi-tools \
+  && cd $HOME/pi-tools \
+  && git reset --hard $PI_TOOLS_GIT_REF; \
+fi
+

--- a/build/user-setup.sh
+++ b/build/user-setup.sh
@@ -1,0 +1,12 @@
+# Setup the cross user
+
+# On OS X, the user needs to have uid set to 1000
+# in order to access files from the shared volumes.
+# https://medium.com/@brentkearney/docker-on-mac-os-x-9793ac024e94
+
+groupadd --system cross && useradd --create-home --system --gid cross --uid 1000 cross;
+
+# When debugging the docker image it really helps if the cross user can sudo
+adduser cross sudo
+echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+


### PR DESCRIPTION
The shell scripts are getting a bit complex in the Dockerfile and also each RUN creates a new layer. I am proposing to move the shell invocations in their own scripts and reduce the number of RUN calls.

Let me know what you think.