### PR TITLE
Add WASM toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG RUST_VERSION=stable
 
 # update system
 RUN apt-get update && \
-  apt-get install -y curl git gcc xz-utils sudo pkg-config unzip
+  apt-get install -y curl git gcc xz-utils sudo pkg-config unzip clang libc6-dev-i386
 
 
 # config and set variables

--- a/build/download-rust.sh
+++ b/build/download-rust.sh
@@ -6,6 +6,8 @@ set -u
 curl https://sh.rustup.rs -sSf > $HOME/install_rustup.sh
 sh $HOME/install_rustup.sh -y --default-toolchain $RUST_VERSION
 $HOME/.cargo/bin/rustup target add arm-unknown-linux-gnueabihf
+$HOME/.cargo/bin/rustup update nightly
+$HOME/.cargo/bin/rustup target add wasm32-unknown-unknown --toolchain nightly
 
 # install pi tools
 if [ $PI_TOOLS_GIT_REF = master ]; \


### PR DESCRIPTION
Add nightly toolchain and wasm target
Add clang and libc6 for building rocksdb

With these additions we can build the [substrate](https://github.com/paritytech/substrate) node and runtime.

We are using rust-on-raspberry-docker to build [joystream-node](https://github.com/Joystream/substrate-node-joystream/blob/441c04b54d16f74b7a5f702a341021d7186df5b1/.travis.yml#L36) for raspberry